### PR TITLE
use Task, but remove Time.Posix

### DIFF
--- a/example/Example.elm
+++ b/example/Example.elm
@@ -76,7 +76,7 @@ update msg model =
 notifyBugsnag : String -> Cmd Msg
 notifyBugsnag errorMessage =
     bugsnagClient.info errorMessage Dict.empty
-        |> Cmd.map (\_ -> NoOp)
+        |> Task.attempt (\_ -> NoOp)
 
 
 json : Json.Encode.Value


### PR DESCRIPTION
Since we don't need the timestamp (uuid and all that retry logic), this seems like a cleaner way to send data to bugsnag.

also some renaming.

### Run Example
Grab the api key from [this bugsnag project](https://app.bugsnag.com/settings/noredink/projects/delete-me) and use it as the [example](https://github.com/NoRedInk/bugsnag-elm/blob/request-response/example/Example.elm#L19) app's api key.

`elm reactor` and visit the example app. You can type in any error message, then send.

Your error should show up in the bugsnag project: https://app.bugsnag.com/noredink/delete-me

### Thoughts? 
Is there any reason this change is a bad idea?  any other need for Task? 